### PR TITLE
Refactor student storage to use objects with IDs

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,7 +176,9 @@
 
   <script>
     // ======= Durum =======
-    const state={version:60,date:'',school:'',klass:'',teacher:'',logo:null,items:{},order:[],pool:[],snap:true,sel:null,selSlot:null, theme:'system'};
+    const state={version:61,date:'',school:'',klass:'',teacher:'',logo:null,items:{},order:[],pool:[],snap:true,sel:null,selSlot:null, theme:'system'};
+    const STORAGE_KEY='planner-v61';
+    const LEGACY_KEYS=['planner-v60'];
     const $=s=>document.querySelector(s), $$=s=>Array.from(document.querySelectorAll(s));
     const paper=$('#paper'), poolEl=$('#studentPool');
     const GRID=16, HEADER_H=parseInt(getComputedStyle(document.documentElement).getPropertyValue('--headerH'))||88; const uid=()=> 'i'+Math.random().toString(36).slice(2,9);
@@ -188,8 +190,90 @@
     const mediaDark=window.matchMedia('(prefers-color-scheme: dark)'); mediaDark.addEventListener?.('change',()=>{ if(state.theme==='system') applyTheme('system'); });
 
     // ======= Depolama =======
-    function saveLocal(){ const data={...state,date:$('#dateInput').value,school:$('#schoolName').value,klass:$('#className').value,teacher:$('#teacherName').value}; localStorage.setItem('planner-v60', JSON.stringify(data)); }
-    function loadLocal(){ const raw=localStorage.getItem('planner-v60'); if(!raw) return; try{ const d=JSON.parse(raw); if(d?.version>=7){ Object.assign(state,d); $('#dateInput').value=d.date||''; $('#schoolName').value=d.school||''; $('#className').value=d.klass||''; $('#teacherName').value=d.teacher||''; $('#snapToggle').checked=!!d.snap; if(d.logo) setLogo(d.logo); refreshHeader(); applyTheme(d.theme||'system'); } }catch(e){}
+    function serializeState(){
+      const data={...state,date:$('#dateInput').value,school:$('#schoolName').value,klass:$('#className').value,teacher:$('#teacherName').value};
+      data.pool=state.pool.map(cloneStudent).filter(Boolean);
+      const items={};
+      Object.entries(state.items).forEach(([id,it])=>{
+        const item={...it};
+        if(item.kind==='desk'){
+          const cap=item.cap===1?1:2;
+          item.cap=cap;
+          item.slots=Array.from({length:cap},(_,idx)=> cloneStudent((it.slots||[])[idx]));
+          item.styles=Array.from({length:cap},(_,idx)=> ensureStyle((it.styles||[])[idx]));
+        } else {
+          item.slots=[];
+          item.styles=(it.styles||[]).map(ensureStyle);
+        }
+        items[id]=item;
+      });
+      data.items=items;
+      data.order=[...state.order].filter(id=>items[id]);
+      data.selSlot=state.selSlot?{...state.selSlot}:null;
+      data.version=state.version;
+      return data;
+    }
+    function migrateState(data){
+      if(!data||typeof data!=='object') return null;
+      const migrated={version:61,date:'',school:'',klass:'',teacher:'',logo:null,items:{},order:[],pool:[],snap:true,sel:null,selSlot:null,theme:'system'};
+      migrated.date=data.date||'';
+      migrated.school=data.school||'';
+      migrated.klass=data.klass||'';
+      migrated.teacher=data.teacher||'';
+      migrated.logo=data.logo||null;
+      migrated.theme=data.theme||'system';
+      migrated.snap=data.snap!==undefined?!!data.snap:true;
+      if(Array.isArray(data.pool)) migrated.pool=data.pool.map(normalizeStudent).filter(Boolean);
+      const srcItems=(data.items&&typeof data.items==='object')?data.items:{};
+      for(const [id,item] of Object.entries(srcItems)){
+        if(!item||typeof item!=='object') continue;
+        const base={...item};
+        base.id=item.id||id;
+        if(base.kind==='desk'){
+          const cap=item.cap===1?1:2;
+          base.cap=cap;
+          const slots=Array.isArray(item.slots)?item.slots:[];
+          base.slots=Array.from({length:cap},(_,idx)=> normalizeStudent(slots[idx]));
+          const styles=Array.isArray(item.styles)?item.styles:[];
+          base.styles=Array.from({length:cap},(_,idx)=> ensureStyle(styles[idx]));
+        } else {
+          base.slots=[];
+          base.styles=Array.isArray(item.styles)?item.styles.map(ensureStyle):[];
+        }
+        migrated.items[id]=base;
+      }
+      migrated.order=Array.isArray(data.order)?data.order.filter(id=>migrated.items[id]):[];
+      migrated.sel=(data.sel&&migrated.items[data.sel])?data.sel:null;
+      if(data.selSlot&&migrated.items[data.selSlot.itemId]&&typeof data.selSlot.idx==='number'&&data.selSlot.idx>=0&&data.selSlot.idx<(migrated.items[data.selSlot.itemId].slots||[]).length){
+        migrated.selSlot={itemId:data.selSlot.itemId,idx:data.selSlot.idx};
+      }
+      return migrated;
+    }
+    function saveLocal(){ const data=serializeState(); localStorage.setItem(STORAGE_KEY, JSON.stringify(data)); LEGACY_KEYS.forEach(k=> localStorage.removeItem(k)); }
+    function loadLocal(){
+      const keys=[STORAGE_KEY,...LEGACY_KEYS];
+      for(const key of keys){
+        const raw=localStorage.getItem(key);
+        if(!raw) continue;
+        try{
+          const parsed=JSON.parse(raw);
+          const data=migrateState(parsed);
+          if(!data) continue;
+          Object.assign(state,data);
+          $('#dateInput').value=state.date||'';
+          $('#schoolName').value=state.school||'';
+          $('#className').value=state.klass||'';
+          $('#teacherName').value=state.teacher||'';
+          $('#snapToggle').checked=!!state.snap;
+          setLogo(state.logo||null);
+          refreshHeader();
+          applyTheme(state.theme||'system');
+          if(key!==STORAGE_KEY) saveLocal();
+          return true;
+        }catch(e){}
+      }
+      return false;
+    }
     }
 
     // ======= Başlık =======
@@ -198,15 +282,21 @@
 
     // ======= Yardımcılar =======
     function clampToPaper(x,y,w,h){ const r=paper.getBoundingClientRect(); const maxX=r.width - w; const minY=HEADER_H; const maxY=r.height - h; return {x:Math.max(0,Math.min(x,maxX)), y:Math.max(minY,Math.min(y,maxY))}; }
+    const DEFAULT_STYLE_COLOR='#111827';
+    const studentId=()=> 's'+Math.random().toString(36).slice(2,9);
+    function ensureStyle(style){ return {bold: style?.bold!==undefined ? !!style.bold : true, color: style?.color || DEFAULT_STYLE_COLOR}; }
+    function cloneStudent(student){ return student?{id:student.id,name:student.name}:null; }
+    function createStudent(name){ const trimmed=(name||'').trim(); if(!trimmed) return null; return {id:studentId(),name:trimmed}; }
+    function normalizeStudent(entry){ if(!entry) return null; if(typeof entry==='string') return createStudent(entry); if(typeof entry==='object'){ const trimmed=(entry.name||'').trim(); if(!trimmed) return null; return {id:entry.id||studentId(),name:trimmed}; } return null; }
     const snapVal=v=> Math.round(v/GRID)*GRID;
     function normalizeLayout(){ state.order.forEach(id=>{ const it=state.items[id]; if(!it) return; const cl=clampToPaper(it.x,it.y,it.w,it.h); it.x=cl.x; it.y=cl.y; }); }
 
     // ======= Öğeler =======
     function makeItem(kind,x=40,y=HEADER_H+20,w=200,h=110,opts={}){
       const id=uid();
-      const base={id,kind,x,y,w,h,cap:2,slots:['',''],styles:[{bold:true,color:'#111827'},{bold:true,color:'#111827'}],label:(opts.label||'Nesne'),locked:false};
+      const base={id,kind,x,y,w,h,cap:2,slots:[null,null],styles:[ensureStyle(),ensureStyle()],label:(opts.label||'Nesne'),locked:false};
       if(kind==='object'){ base.w=170;base.h=90;base.cap=0;base.slots=[];base.styles=[]; }
-      if(kind==='desk' && opts.cap===1){ base.cap=1;base.slots=[''];base.styles=[{bold:true,color:'#111827'}];base.w=170;base.h=104; }
+      if(kind==='desk' && opts.cap===1){ base.cap=1;base.slots=[null];base.styles=[ensureStyle()];base.w=170;base.h=104; }
       state.items[id]=base; state.order.push(id); return id;
     }
     function render(){ paper.querySelectorAll('.item').forEach(n=>n.remove()); state.order.forEach(id=> paper.appendChild(renderItem(state.items[id])) ); highlightSelection(); highlightSlot(); }
@@ -217,17 +307,62 @@
       if(it.kind==='desk'){
         const capBtn=document.createElement('button'); capBtn.className='btn'; capBtn.style.padding='6px 10px'; capBtn.textContent= it.cap===1?'1 kişi':'2 kişi'; capBtn.title='Kapasite: 1/2'; capBtn.addEventListener('click',()=> setDeskCapacity(it.id,it.cap===1?2:1)); handle.appendChild(capBtn);
         const body=document.createElement('div'); body.className='desk-body'; body.addEventListener('dragover',e=>{ if(e.dataTransfer?.types?.includes('text/student')) e.preventDefault(); }); body.addEventListener('drop',e=>{ if(e.dataTransfer?.types?.includes('text/student')){ e.preventDefault(); placeToDesk(it.id, e.dataTransfer.getData('text/student')); }});
-        const cnt=it.cap===1?1:2; for(let i=0;i<cnt;i++){ body.appendChild(slotNode(it.id,i,it.slots[i]||'')); } el.appendChild(body);
+        const cnt=it.cap===1?1:2; for(let i=0;i<cnt;i++){ body.appendChild(slotNode(it.id,i,it.slots[i]||null)); } el.appendChild(body);
       } else { const badge=document.createElement('div'); badge.className='badge'; badge.textContent=it.label||'Nesne'; badge.addEventListener('click',()=>{ if(it.locked) return; const inp=document.createElement('input'); inp.type='text'; inp.value=it.label||''; Object.assign(inp.style,{fontSize:'12px',padding:'4px 8px',border:'1px solid var(--line)',borderRadius:'999px',background:'var(--paper)',color:'var(--ink)'}); badge.replaceWith(inp); inp.focus(); inp.select(); const commit=()=>{ it.label=inp.value.trim()||'Nesne'; render(); saveLocal(); }; inp.addEventListener('keydown',e=>{ if(e.key==='Enter') commit(); if(e.key==='Escape') render(); }); inp.addEventListener('blur',commit); }); el.appendChild(badge); }
       enableSelect(el); if(!it.locked){ enableDrag(el,handle); enableResize(el,res); }
       return el;
     }
-    function slotNode(itemId,idx,text){ const s=document.createElement('div'); s.className='slot'; const it=state.items[itemId]; const st=(it.styles&&it.styles[idx])||{bold:true,color:'#111827'}; s.style.color=st.color||'#111827'; s.style.fontWeight=st.bold?'900':'700'; s.textContent=text||''; s.addEventListener('mousedown',()=>{ state.sel=itemId; state.selSlot={itemId,idx}; highlightSelection(); highlightSlot(); syncStylePanel(st); }); s.addEventListener('touchstart',()=>{ state.sel=itemId; state.selSlot={itemId,idx}; highlightSelection(); highlightSlot(); syncStylePanel(st); },{passive:true}); s.addEventListener('click',()=>{ if(it.locked) return; s.classList.add('editing'); s.innerHTML=''; const inp=document.createElement('input'); inp.type='text'; inp.value=text||''; s.appendChild(inp); inp.focus(); inp.select(); const commit=()=>{ const val=inp.value.trim(); it.slots[idx]=val; state.pool=state.pool.filter(n=> n!==val); renderPool(); render(); saveLocal(); }; inp.addEventListener('keydown',e=>{ if(e.key==='Enter') commit(); if(e.key==='Escape') render(); }); inp.addEventListener('blur',commit); }); s.addEventListener('dblclick',()=>{ if(it.locked) return; const name=it.slots[idx]; if(name){ state.pool.push(name); it.slots[idx]=''; renderPool(); render(); saveLocal(); }}); return s; }
+    function slotNode(itemId,idx,student){
+      const s=document.createElement('div'); s.className='slot';
+      const it=state.items[itemId];
+      const styles=it.styles||(it.styles=[]);
+      if(!styles[idx]) styles[idx]=ensureStyle();
+      const st=styles[idx];
+      s.style.color=st.color||DEFAULT_STYLE_COLOR; s.style.fontWeight=st.bold?'900':'700'; s.textContent=student?.name||'';
+      const selectSlot=()=>{ state.sel=itemId; state.selSlot={itemId,idx}; highlightSelection(); highlightSlot(); syncStylePanel(st); };
+      s.addEventListener('mousedown',selectSlot);
+      s.addEventListener('touchstart',selectSlot,{passive:true});
+      s.addEventListener('click',()=>{ if(it.locked) return; s.classList.add('editing'); s.innerHTML=''; const inp=document.createElement('input'); inp.type='text'; inp.value=student?.name||''; s.appendChild(inp); inp.focus(); inp.select(); const commit=()=>{ const val=inp.value.trim(); const existing=it.slots[idx]; if(!val){ it.slots[idx]=null; } else if(existing){ existing.name=val; it.slots[idx]=existing; } else { it.slots[idx]={id:studentId(),name:val}; } render(); saveLocal(); }; inp.addEventListener('keydown',e=>{ if(e.key==='Enter') commit(); if(e.key==='Escape') render(); }); inp.addEventListener('blur',commit); });
+      s.addEventListener('dblclick',()=>{ if(it.locked) return; const current=it.slots[idx]; if(current){ state.pool.push(current); it.slots[idx]=null; renderPool(); render(); saveLocal(); }});
+      return s;
+    }
     function highlightSelection(){ $$('.item').forEach(n=> n.classList.toggle('selected', n.dataset.id===state.sel)); }
     function highlightSlot(){ $$('.slot').forEach(n=> n.classList.remove('sel')); if(state.selSlot){ const {itemId,idx}=state.selSlot; const cont=[...paper.querySelectorAll(`.item[data-id="${itemId}"] .slot`)]; const el=cont[idx]; if(el) el.classList.add('sel'); }}
     function syncStylePanel(st){ $('#styleColor').value = st?.color||'#111827'; $('#styleBold').checked = !!st?.bold; }
-    function setDeskCapacity(id,cap){ const it=state.items[id]; if(it.kind!=='desk') return; it.cap=cap===1?1:2; if(it.cap===1){ if(it.slots[1]) state.pool.push(it.slots[1]); it.slots=[it.slots[0]]; it.styles=[it.styles[0]||{bold:true,color:'#111827'}]; } else { if(it.slots.length<2) it.slots[1]=''; if(!it.styles) it.styles=[]; if(!it.styles[0]) it.styles[0]={bold:true,color:'#111827'}; if(!it.styles[1]) it.styles[1]={bold:true,color:'#111827'}; } renderPool(); render(); saveLocal(); }
-    function placeToDesk(id,name){ const it=state.items[id]; const cnt=it.cap===1?1:2; const idx=it.slots.slice(0,cnt).findIndex(v=>!v); if(idx>-1){ it.slots[idx]=name; } else { const old=it.slots[0]; if(old) state.pool.push(old); it.slots[0]=name; } state.pool=state.pool.filter(n=>n!==name); renderPool(); render(); saveLocal(); }
+    function setDeskCapacity(id,cap){
+      const it=state.items[id];
+      if(it.kind!=='desk') return;
+      const newCap=cap===1?1:2;
+      if(newCap===1){
+        const removed=it.slots?.[1];
+        if(removed) state.pool.push(removed);
+        const first=it.slots?.[0]||null;
+        it.slots=[first];
+        it.styles=[ensureStyle(it.styles?.[0])];
+      } else {
+        const slots=it.slots||[];
+        it.slots=[slots[0]||null, slots[1]||null];
+        it.styles=[ensureStyle(it.styles?.[0]), ensureStyle(it.styles?.[1])];
+      }
+      it.cap=newCap;
+      renderPool(); render(); saveLocal();
+    }
+    function placeToDesk(id,token){
+      const it=state.items[id];
+      if(!it||it.kind!=='desk'||!token) return;
+      let student=null;
+      let idx=state.pool.findIndex(s=>s.id===token);
+      if(idx>-1){ student=state.pool.splice(idx,1)[0]; }
+      if(!student){
+        try{ const parsed=JSON.parse(token); if(parsed&&parsed.id){ idx=state.pool.findIndex(s=>s.id===parsed.id); if(idx>-1){ student=state.pool.splice(idx,1)[0]; } else { student=normalizeStudent(parsed); } } }catch(e){}
+      }
+      if(!student){ idx=state.pool.findIndex(s=>s.name===token); if(idx>-1){ student=state.pool.splice(idx,1)[0]; } }
+      if(!student) return;
+      const cnt=it.cap===1?1:2; const empty=it.slots.slice(0,cnt).findIndex(v=>!v);
+      if(empty>-1){ it.slots[empty]=student; }
+      else { const old=it.slots[0]; if(old) state.pool.push(old); it.slots[0]=student; }
+      renderPool(); render(); saveLocal();
+    }
 
     // ======= Seçim / Sürükleme / Boyutlandırma =======
     function enableSelect(el){ el.addEventListener('mousedown',()=>{ state.sel=el.dataset.id; highlightSelection(); }); el.addEventListener('touchstart',()=>{ state.sel=el.dataset.id; highlightSelection(); },{passive:true}); }
@@ -236,9 +371,9 @@
     function enableResize(el,grip){ let sx=0,sy=0,sw=0,sh=0,id=el.dataset.id; grip.addEventListener('mousedown',down); grip.addEventListener('touchstart',down,{passive:false}); function down(e){ e.preventDefault(); const p=e.touches?e.touches[0]:e; sx=p.clientX; sy=p.clientY; const it=state.items[id]; sw=it.w; sh=it.h; document.addEventListener('mousemove',move); document.addEventListener('mouseup',up); document.addEventListener('touchmove',move,{passive:false}); document.addEventListener('touchend',up);} function move(e){ const p=e.touches?e.touches[0]:e; const it=state.items[id]; let nw=sw+(p.clientX-sx); let nh=sh+(p.clientY-sy); if(it.kind==='desk'){ nw=Math.max(it.cap===1?150:180,nw); nh=Math.max(100,nh);} else { nw=Math.max(60,nw); nh=Math.max(50,nh);} if(state.snap){ nw=Math.max(60,snapVal(nw)); nh=Math.max(50,snapVal(nh)); } const r=paper.getBoundingClientRect(); it.w=Math.min(nw, r.width-it.x); it.h=Math.min(nh, r.height-it.y); el.style.width=it.w+'px'; el.style.height=it.h+'px'; } function up(){ document.removeEventListener('mousemove',move); document.removeEventListener('mouseup',up); document.removeEventListener('touchmove',move); document.removeEventListener('touchend',up); saveLocal(); } }
 
     // ======= Havuz =======
-    function renderPool(){ poolEl.innerHTML=''; state.pool.forEach(n=> poolEl.appendChild(pill(n)) ); }
-    function pill(name){ const el=document.createElement('div'); el.className='pill'; el.textContent=name; el.draggable=true; el.addEventListener('dragstart',ev=>{ ev.dataTransfer.setData('text/student', name); ev.dataTransfer.effectAllowed='move'; }); return el; }
-    $('#loadNames').addEventListener('click',()=>{ const txt=$('#names').value.trim(); const items=txt.split(/\n+/).map(s=>s.trim()).filter(Boolean); const placed=new Set(Object.values(state.items).flatMap(it=>it.slots||[])); const poolSet=new Set(state.pool); const add=items.filter(n=>!placed.has(n)&&!poolSet.has(n)); state.pool.push(...add); renderPool(); saveLocal(); });
+    function renderPool(){ poolEl.innerHTML=''; state.pool.forEach(stu=>{ if(!stu) return; poolEl.appendChild(pill(stu)); }); }
+    function pill(student){ const el=document.createElement('div'); el.className='pill'; el.textContent=student.name; el.draggable=true; el.dataset.id=student.id; el.addEventListener('dragstart',ev=>{ ev.dataTransfer.setData('text/student', student.id); ev.dataTransfer.setData('text/plain', student.name); ev.dataTransfer.effectAllowed='move'; }); return el; }
+    $('#loadNames').addEventListener('click',()=>{ const txt=$('#names').value.trim(); if(!txt) return; const items=txt.split(/\n+/).map(s=>createStudent(s)).filter(Boolean); state.pool.push(...items); renderPool(); saveLocal(); });
     $('#clearNames').addEventListener('click',()=>{ state.pool=[]; renderPool(); saveLocal(); });
 
     // ======= Girişler =======
@@ -261,12 +396,12 @@
     // ======= Araç çubuğu =======
     $('#btnPrint').addEventListener('click', printPaper);
     $('#btnExport').addEventListener('click', exportPNG);
-    $('#btnBackup').addEventListener('click',()=>{ const payload={...state}; const blob=new Blob([JSON.stringify(payload,null,2)],{type:'application/json'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download=`sinif-plani_${new Date().toISOString().slice(0,10)}.json`; a.click(); URL.revokeObjectURL(a.href); });
+    $('#btnBackup').addEventListener('click',()=>{ const payload=serializeState(); const blob=new Blob([JSON.stringify(payload,null,2)],{type:'application/json'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download=`sinif-plani_${new Date().toISOString().slice(0,10)}.json`; a.click(); URL.revokeObjectURL(a.href); });
     $('#btnRestore').addEventListener('click',()=> hiddenInput.click());
 
     // Gizli dosya inputu
     const hiddenInput=document.createElement('input'); hiddenInput.type='file'; hiddenInput.accept='application/json'; hiddenInput.style.display='none'; document.body.appendChild(hiddenInput);
-    hiddenInput.addEventListener('change',ev=>{ const f=ev.target.files[0]; if(!f) return; const r=new FileReader(); r.onload=()=>{ try{ const data=JSON.parse(r.result); if(data.version>=7){ Object.assign(state,data); $('#schoolName').value=state.school||''; $('#className').value=state.klass||''; $('#teacherName').value=state.teacher||''; $('#dateInput').value=state.date||''; $('#snapToggle').checked=!!state.snap; setLogo(state.logo||null); refreshHeader(); applyTheme(state.theme||'system'); render(); renderPool(); saveLocal(); } else { alert('Desteklenmeyen sürüm.'); } }catch(e){ alert('Geçersiz dosya.'); } }; r.readAsText(f); });
+    hiddenInput.addEventListener('change',ev=>{ const f=ev.target.files[0]; if(!f) return; const r=new FileReader(); r.onload=()=>{ try{ const parsed=JSON.parse(r.result); const data=migrateState(parsed); if(!data) throw new Error('invalid'); Object.assign(state,data); $('#schoolName').value=state.school||''; $('#className').value=state.klass||''; $('#teacherName').value=state.teacher||''; $('#dateInput').value=state.date||''; $('#snapToggle').checked=!!state.snap; setLogo(state.logo||null); refreshHeader(); applyTheme(state.theme||'system'); render(); renderPool(); saveLocal(); }catch(e){ alert('Geçersiz dosya.'); } }; r.readAsText(f); });
 
     // ======= Toggle'lar =======
     $('#snapToggle').addEventListener('change',e=>{ state.snap=e.target.checked; saveLocal(); });
@@ -275,7 +410,7 @@
     // ======= Klavye =======
     document.addEventListener('keydown',e=>{ const it=currentItem(); if(!it) return; if(e.key==='Delete' || e.key==='Backspace'){ delete state.items[it.id]; state.order=state.order.filter(x=>x!==it.id); state.sel=null; state.selSlot=null; render(); saveLocal(); }
       if(e.key==='l'){ it.locked=!it.locked; render(); saveLocal(); }
-      if((e.ctrlKey||e.metaKey) && e.key.toLowerCase()==='d'){ const id=makeItem(it.kind,it.x+24,it.y+24,it.w,it.h,{label:it.label,cap:it.cap}); const n=state.items[id]; if(it.kind==='desk'){ n.cap=it.cap; n.slots=[...it.slots]; n.styles=it.styles.map(o=>({...o})); } n.locked=it.locked; render(); saveLocal(); e.preventDefault(); }
+      if((e.ctrlKey||e.metaKey) && e.key.toLowerCase()==='d'){ const id=makeItem(it.kind,it.x+24,it.y+24,it.w,it.h,{label:it.label,cap:it.cap}); const n=state.items[id]; if(it.kind==='desk'){ n.cap=it.cap; n.slots=Array.from({length:n.cap},(_,idx)=>{ const s=it.slots[idx]; return s?{id:studentId(),name:s.name}:null; }); n.styles=Array.from({length:n.cap},(_,idx)=> ensureStyle((it.styles||[])[idx])); } n.locked=it.locked; render(); saveLocal(); e.preventDefault(); }
     });
 
     // ======= Çekmece (aynı panel) =======


### PR DESCRIPTION
## Summary
- store students in the pool and desk slots as `{id, name}` objects instead of raw strings
- update drag and drop, slot editing, name loading, and desk capacity helpers to work with object IDs without de-duplicating by name
- add serialization/migration logic so backups, local storage, and exports continue to work across the new structure

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc77fb27648326a2f7bd8dafc9246c